### PR TITLE
Two links on "Installation using Docker" do not route correctly.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -124,7 +124,7 @@ or LDAP server setup. If you wish to use a local OpenLDAP instance, follow the
 [Using OpenLDAP for Authentication](./development.html#oldap) guide.
 
 The configuration file format and available parameters described in the
-[Configuration](./configuration.html) document.
+[Configuration](../configuration.html) document.
 
 ### Step 3. Start the Concord Server
 
@@ -193,7 +193,7 @@ Try logging in using your AD/LDAP credentials.
 ## First Project
 
 As a next step you can create your first project as detailed in the
-[quickstart guide](./quickstart.html).
+[quickstart guide](../quickstart.html).
 
 
 ## Clean Up


### PR DESCRIPTION
Two links "configuration" and "quick start guide" are not routing because they are referring to "install" directory and not the parent "getting-started" directory.