### PR TITLE
Use the external rubygems.org

### DIFF
--- a/docs/plugins/terraform.md
+++ b/docs/plugins/terraform.md
@@ -158,6 +158,7 @@ structure:
 
 [Input variables](https://www.terraform.io/docs/configuration/variables.html)
 can be specified using the `extraVars` parameter:
+
 ```yaml
 - task: terraform
   in:
@@ -222,17 +223,10 @@ the `apply` action parameters:
 
 ## State Backends
 
-By default Concord provides its own
-[state backend](https://www.terraform.io/docs/backends/index.html) based on
-the [http backend](https://www.terraform.io/docs/backends/types/http.html).
+Concord uses its own
+[state backend](https://www.terraform.io/docs/backends/index.html) by default, but any of the standard Terraform state backends can be configured for use.
 
-Currently, the data is stored in Concord Inventory. Terraform uses previously
-saved data to calculate necessary changes to the environment and stores the
-updated state whenever changes are made.
-
-By default, the plugin automatically creates a new inventory using
-the `tfState-${projectName}_${repositoryName}` template for the name.
-It can be overridden using the `stateId` parameter:
+When using the Concord state backend, on by default, the state is stored in Concord's internal [inventory system](https://concord.walmartlabs.com/docs/api/inventory.html) using the `tfState-${projectName}_${repositoryName}` template for the name. If you want to use a custom name for storing the state, the name can be overridden using the `stateId` parameter:
 
 ```yaml
 - task: terraform
@@ -241,10 +235,24 @@ It can be overridden using the `stateId` parameter:
     stateId: "myInventory"
 ```
 
-To completely remove the saved state remove the inventory using the [API](../api/inventory.html#delete-inventory). 
+To completely remove the state, you can use the inventory [API](../api/inventory.html#delete-inventory). 
 
-If your Terraform configuration uses a backend other then the `default` backend,
-then you must disable the default backend:
+Concord also supports the use of all [Terraform's backend types](https://www.terraform.io/docs/backends/types/index.html). To instruct the plugin to use the `s3` backend for storing state, use something like the following:
+
+```
+- task: terraform
+  in:
+    backend:
+      s3:
+        bucket: "tfstate"
+        key: "project"
+        region: "us-west-2"
+        encrypt: true
+        dynamodb_table: "project-lock"
+```        
+
+You can also disable the use of all state backends by specifying a backend of `none`. This is effectively the same as the default command line behavior that uses the filesystem to store state in the `terraform.tfstate`. To instruct the plugin to use no backend for storing state, use something like the following:
+
 
 ```yaml
 - task: terraform
@@ -262,6 +270,7 @@ as modules may require SSH key authentication. The plugin provides a couple ways
 configure the keys.
 
 Using private key files directly:
+
 ```yaml
 - task: terraform
   in:
@@ -274,6 +283,7 @@ Using private key files directly:
 The path must be relative to the process `${workDir}`.
 
 An alternative (and recommended) way is to use Concord [Secrets](../api/secret.html):
+
 ```yaml
 - task: terraform
   in:


### PR DESCRIPTION
References to the internal walmartlabs gem repository makes it impossible for
external users to generate the site.